### PR TITLE
Force encoding when running process on raw data

### DIFF
--- a/api/dataset/services/dataset.js
+++ b/api/dataset/services/dataset.js
@@ -121,7 +121,10 @@ module.exports = {
       }
       let source;
       try {
-        source = JSON.parse(text);
+        let encode_utf8 = function(str) {
+          return unescape(encodeURIComponent(str))
+        }
+        source = JSON.parse(encode_utf8(text));
       } catch (err) {
         // disable processing and log event
         await strapi


### PR DESCRIPTION
Force each processed raw data string into utf-8. This appears to be directly supported by the api, database, and UI. An example is the extracted pdf data.

An easy test case is to run process on `tephrabase` and review results. 



